### PR TITLE
Fix optional update schemas

### DIFF
--- a/sitebuilder/app/routers/elements.py
+++ b/sitebuilder/app/routers/elements.py
@@ -14,7 +14,7 @@ def create_element(el_in: schemas.ElementCreate, db: Session = Depends(get_sessi
     return el
 
 @router.patch("/{el_id}", response_model=schemas.ElementRead)
-def update_element(el_id: int, el_in: schemas.ElementCreate, db: Session = Depends(get_session)):
+def update_element(el_id: int, el_in: schemas.ElementUpdate, db: Session = Depends(get_session)):
     el = db.get(models.Element, el_id)
     if not el:
         raise HTTPException(status_code=404)

--- a/sitebuilder/app/routers/pages.py
+++ b/sitebuilder/app/routers/pages.py
@@ -22,7 +22,7 @@ def read_page(page_id: int, db: Session = Depends(get_session)):
     return page
 
 @router.patch("/{page_id}", response_model=schemas.PageRead)
-def update_page(page_id: int, page_in: schemas.PageCreate, db: Session = Depends(get_session)):
+def update_page(page_id: int, page_in: schemas.PageUpdate, db: Session = Depends(get_session)):
     page = db.get(models.Page, page_id)
     if not page:
         raise HTTPException(status_code=404)

--- a/sitebuilder/app/schemas.py
+++ b/sitebuilder/app/schemas.py
@@ -8,6 +8,10 @@ class ElementBase(BaseModel):
     position: int
 
 class ElementCreate(ElementBase): pass
+class ElementUpdate(BaseModel):
+    type: Optional[str] = None
+    content: Optional[str] = None
+    position: Optional[int] = None
 class ElementRead(ElementBase):
     id: int
 
@@ -16,6 +20,9 @@ class PageBase(BaseModel):
     path: str
 
 class PageCreate(PageBase): pass
+class PageUpdate(BaseModel):
+    title: Optional[str] = None
+    path: Optional[str] = None
 class PageRead(PageBase):
     id: int
     elements: List[ElementRead] = []


### PR DESCRIPTION
## Summary
- add `PageUpdate` and `ElementUpdate` schemas
- allow partial updates in page and element routers

## Testing
- `PYTHONPATH=ExPlast pytest -q ExPlast/sitebuilder/backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68638d2b4a408332b3622ff4ec55bd6e