### PR TITLE
Read DATABASE_URL from env

### DIFF
--- a/ExPlast/sitebuilder/backend/app/database.py
+++ b/ExPlast/sitebuilder/backend/app/database.py
@@ -1,7 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+import os
 
-DATABASE_URL = "sqlite:///./builder.db"   # файл появится рядом с кодом
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./builder.db")   # файл появится рядом с кодом
 
 engine = create_engine(DATABASE_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/README
+++ b/README
@@ -55,6 +55,14 @@ python -m uvicorn sitebuilder.backend.app.main:app --reload
 # 👉 http://127.0.0.1:8000/docs  — Swagger API
 ```
 
+По умолчанию SQLite-база размещается в файле `builder.db`. При желании можно
+переопределить путь к базе через переменную окружения `DATABASE_URL`,
+например:
+
+```bash
+export DATABASE_URL=postgresql://user:pass@localhost/dbname
+```
+
 ---
 
 ## ⚙️ CLI-скрипты


### PR DESCRIPTION
## Summary
- allow overriding DB location via `DATABASE_URL`
- document the new `DATABASE_URL` variable

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863eb9fc108833280eed765924eada1