### PR TITLE
Implement project deletion

### DIFF
--- a/ExPlast/sitebuilder/backend/app/crud.py
+++ b/ExPlast/sitebuilder/backend/app/crud.py
@@ -59,6 +59,14 @@ def list_projects(db: Session):
         for pr in db.query(models.Project).order_by(models.Project.id).all()
     ]
 
+def delete_project(db: Session, pid: int) -> bool:
+    pr = db.query(models.Project).filter_by(id=pid).first()
+    if not pr:
+        return False
+    db.delete(pr)
+    db.commit()
+    return True
+
 
 # ─── Pages CRUD ───────────────────────────────────────────────
 def create_page(db: Session, pid: int, page: schemas.PageCreate):

--- a/ExPlast/sitebuilder/backend/app/main.py
+++ b/ExPlast/sitebuilder/backend/app/main.py
@@ -36,6 +36,11 @@ def update_project(pid: int, proj: schemas.ProjectUpdate, db: Session = Depends(
         raise HTTPException(404, 'Not found')
     return pr
 
+@app.delete('/projects/{pid}', status_code=204)
+def delete_project(pid: int, db: Session = Depends(get_db)):
+    if not crud.delete_project(db, pid):
+        raise HTTPException(404, 'Not found')
+
 
 # ─────────────────────── страницы CRUD ───────────────────────
 @app.post('/projects/{pid}/pages',  response_model=schemas.PageOut, status_code=201)

--- a/ExPlast/sitebuilder/backend/tests/test_projects.py
+++ b/ExPlast/sitebuilder/backend/tests/test_projects.py
@@ -24,3 +24,9 @@ def test_update():
     r = client.put(f"/projects/{pid}", json={"name": "Y", "data": {}})
     assert r.status_code == 200
     assert r.json()["name"] == "Y"
+
+def test_delete():
+    pid = client.post("/projects/", json={"name": "Demo", "data": {}}).json()["id"]
+    r = client.delete(f"/projects/{pid}")
+    assert r.status_code == 204
+    assert client.get(f"/projects/{pid}").status_code == 404


### PR DESCRIPTION
## Summary
- implement `delete_project` helper
- expose project DELETE endpoint in API
- test deleting projects

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863eb6d522c833287bd8ccde687013d