### PR TITLE
Improve project load/reset

### DIFF
--- a/ExPlast/frontend/main.js
+++ b/ExPlast/frontend/main.js
@@ -139,6 +139,10 @@ btnCreate.onclick = async ()=>{
   if(!name) return;
   const pr = await api('POST','/projects/',{name,data:{}});
   curPid = pr.id;
+  // новый проект должен начинаться с чистого состояния
+  editor.loadProjectData({pages: []});
+  Pages.add({id:'index',name:'index',component:'<h1>Главная</h1>'});
+  Pages.select('index');
   alert(`Создано (#${curPid})`);
 };
 
@@ -148,7 +152,7 @@ btnLoad.onclick = async ()=>{
   curPid = id;
   try{
     const {data} = await api('GET',`/projects/${id}`);
-    editor.loadProjectData(data.project || {});
+    editor.loadProjectData(data.project || {pages: []});
     if(!Pages.getAll().length){
       Pages.add({id:'index',name:'index',component:'<h1>Главная</h1>'});
       Pages.select('index');


### PR DESCRIPTION
## Summary
- reset GrapesJS state when creating a new project
- ensure loading empty projects clears pages

## Testing
- `pip install fastapi==0.111.0 uvicorn==0.30.0 SQLAlchemy==2.0.30 pydantic==2.7.1 pytest==8.2.0 httpx==0.27.0`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ea23d25483328493ea176485ee03