### PR TITLE
Add modern toolbar with Font Awesome

### DIFF
--- a/ExPlast/frontend/index.html
+++ b/ExPlast/frontend/index.html
@@ -6,45 +6,26 @@
 
   <!-- GrapesJS -->
   <script src="https://cdn.jsdelivr.net/npm/grapesjs@0.22.1/dist/grapes.min.js"></script>
-  <link  href="https://cdn.jsdelivr.net/npm/grapesjs@0.22.1/dist/css/grapes.min.css" rel="stylesheet"/>
+  <link href="https://cdn.jsdelivr.net/npm/grapesjs@0.22.1/dist/css/grapes.min.css" rel="stylesheet"/>
+
+  <!-- Иконки и стили -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <link href="style.css" rel="stylesheet"/>
 
   <!-- Плагины -->
   <script src="https://cdn.jsdelivr.net/npm/grapesjs-preset-webpage@1.0.2/dist/grapesjs-preset-webpage.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/grapesjs-plugin-absolute@1.0.1/dist/grapesjs-plugin-absolute.min.js"></script>
 
-  <style>
-    html,body{margin:0;height:100%}
-    #gjs{height:calc(100vh - 54px)}
-
-    /* шапка */
-    #topBar{padding:6px;background:#f0f0f0;display:flex;gap:6px;align-items:center;font:14px/1 Arial}
-
-    /* панель страниц */
-    #pagesBar select{padding:3px;border:1px solid #999;border-radius:4px}
-    #pagesBar button{padding:3px 6px}
-
-    /* плавающая мини-панель */
-    .toolbar{
-      position:fixed;left:50%;top:60px;transform:translateX(-50%);
-      display:flex;gap:6px;z-index:9999;
-      background:#fff;border:1px solid #c7c7c7;border-radius:8px;
-      padding:4px 8px;box-shadow:0 2px 8px rgba(0,0,0,.15);
-      font:13px/1 Arial;
-    }
-    .toolbar button{border:1px solid #b3b3b3;background:#f8f8f8;border-radius:4px;
-                    padding:3px 6px;cursor:pointer;min-width:28px}
-    .toolbar button:hover{background:#ececec}
-    #colorPick{border:1px solid #b3b3b3;border-radius:4px;width:32px;height:23px;padding:0}
-  </style>
+  
 </head>
 <body>
 
   <!-- ── верхняя панель ── -->
   <div id="topBar">
-    <button id="btnCreate">Создать</button>
-    <button id="btnLoad">Загрузить</button>
-    <button id="btnSave">Сохранить</button>
-    <button id="btnExport">Экспорт</button>
+    <button id="btnCreate"><i class="fa fa-file-circle-plus"></i><span> Создать</span></button>
+    <button id="btnLoad"><i class="fa fa-folder-open"></i><span> Загрузить</span></button>
+    <button id="btnSave"><i class="fa fa-floppy-disk"></i><span> Сохранить</span></button>
+    <button id="btnExport"><i class="fa fa-file-export"></i><span> Экспорт</span></button>
 
     <!-- панель страниц -->
     <div id="pagesBar" style="margin-left:32px;display:flex;gap:4px">
@@ -58,12 +39,7 @@
 
   <!-- мини-панель -->
   <div id="inlineToolbar" class="toolbar" hidden>
-    <button data-cmd="bold"   title="Жирный (Ctrl+B)">Ж</button>
-    <button data-cmd="italic" title="Курсив (Ctrl+I)">К</button>
-    <button data-cmd="h1"     title="Заголовок 1">H1</button>
-    <button data-cmd="h2"     title="Заголовок 2">H2</button>
     <input  type="color" id="colorPick" title="Цвет текста">
-    <button id="imgReplace" hidden title="Заменить картинку">🖼</button>
     <label title="К правому краю" style="user-select:none">
       ⇢<input type="checkbox" id="anchorRight" style="margin-left:4px">
     </label>

--- a/ExPlast/frontend/main.js
+++ b/ExPlast/frontend/main.js
@@ -80,39 +80,39 @@ editor.BlockManager.add('int-link',{
 /* ─────────────────────────────  МИНИ-ПАНЕЛЬ  ───────────────────────────── */
 const bar=document.getElementById('inlineToolbar'),
       pick=document.getElementById('colorPick'),
-      imgBtn=document.getElementById('imgReplace'),
       chkRight=document.getElementById('anchorRight'),
       chkBottom=document.getElementById('anchorBottom');
 
+const panel=editor.Panels.addPanel({id:'inline',el:bar,visible:false});
+
+function addBtn(id, icon, title, run){
+  editor.Commands.add(id,{run});
+  editor.Panels.addButton('inline',{id,className:`fa ${icon}`,command:id,attributes:{title}});
+}
+
+addBtn('bold','fa-bold','Жирный',ed=>ed.runCommand('core:exec-command',{command:'bold'}));
+addBtn('italic','fa-italic','Курсив',ed=>ed.runCommand('core:exec-command',{command:'italic'}));
+addBtn('h1','fa-heading','H1',ed=>ed.runCommand('core:exec-command',{command:'h1'}));
+addBtn('h2','fa-heading','H2',ed=>ed.runCommand('core:exec-command',{command:'h2'}));
+addBtn('align-left','fa-align-left','Выровнять слева',ed=>{const s=ed.getSelected();s&&s.addStyle({'text-align':'left'});});
+addBtn('align-center','fa-align-center','Выровнять по центру',ed=>{const s=ed.getSelected();s&&s.addStyle({'text-align':'center'});});
+addBtn('align-right','fa-align-right','Выровнять справа',ed=>{const s=ed.getSelected();s&&s.addStyle({'text-align':'right'});});
+addBtn('font-inc','fa-plus','Крупнее',ed=>{const s=ed.getSelected();if(!s)return;const fs=parseInt(s.getStyle()['font-size'])||16;s.addStyle({'font-size':(fs+2)+'px'});});
+addBtn('font-dec','fa-minus','Мельче',ed=>{const s=ed.getSelected();if(!s)return;const fs=parseInt(s.getStyle()['font-size'])||16;s.addStyle({'font-size':Math.max(8,fs-2)+'px'});});
+addBtn('link','fa-link','Ссылка',ed=>{const s=ed.getSelected();if(!s)return;const u=prompt('URL','https://');u&&s.addAttributes({href:u});});
+addBtn('img-replace','fa-image','Картинка',ed=>{const s=ed.getSelected();if(!s)return;const i=document.createElement('input');i.type='file';i.accept='image/*';i.onchange=ev=>{const f=ev.target.files[0],r=new FileReader();r.onload=e2=>s.set('src',e2.target.result);r.readAsDataURL(f);};i.click();});
+
+const imgBtn=panel.get('buttons').find(b=>b.id==='img-replace');
+
 editor.on('component:selected', sel=>{
   if(!sel||sel.is('wrapper')) return bar.hidden=true;
-  const r=sel.view.el.getBoundingClientRect();
-  bar.style.top =(r.top-50)+'px';
-  bar.style.left=(r.left+r.width/2)+'px';
   bar.hidden=false;
-  imgBtn.hidden=sel.get('type')!=='image';
+  imgBtn&&imgBtn.set('visible',sel.get('type')==='image');
   chkRight.checked=!!sel.getAttributes()['data-anchor-right'];
   chkBottom.checked=!!sel.getAttributes()['data-anchor-bottom'];
 });
-bar.onclick = e=>{
-  const cmd=e.target.dataset.cmd;
-  cmd && editor.Commands.run('core:exec-command',{command:cmd});
-};
-pick.oninput=e=>{
-  const s=editor.getSelected();
-  s && s.addStyle({color:e.target.value});
-};
-imgBtn.onclick=()=>{
-  const s=editor.getSelected();if(!s)return;
-  const i=document.createElement('input');
-  i.type='file';i.accept='image/*';
-  i.onchange=ev=>{
-    const f=ev.target.files[0],r=new FileReader();
-    r.onload=e2=>s.set('src',e2.target.result);
-    r.readAsDataURL(f);
-  };
-  i.click();
-};
+
+pick.oninput=e=>{const s=editor.getSelected();s&&s.addStyle({color:e.target.value});};
 
 function normalizePos(sel){
   const frame=editor.Canvas.getFrameEl();

--- a/ExPlast/frontend/style.css
+++ b/ExPlast/frontend/style.css
@@ -1,0 +1,65 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+
+html,body{
+  margin:0;
+  height:100%;
+  font-family:'Roboto',sans-serif;
+}
+
+#gjs{height:calc(100vh - 54px)}
+
+/* верхняя панель */
+#topBar{
+  padding:6px;
+  background:#3a3f44;
+  display:flex;
+  gap:8px;
+  align-items:center;
+  color:#fff;
+}
+#topBar button{
+  background:#4b86c2;
+  border:none;
+  color:#fff;
+  padding:4px 8px;
+  border-radius:4px;
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  gap:4px;
+  transition:background-color .2s;
+}
+#topBar button:hover{background:#3973a1;}
+
+/* панель страниц */
+#pagesBar select{padding:3px;border:1px solid #777;border-radius:4px}
+#pagesBar button{padding:3px 6px}
+
+/* боковая мини-панель */
+.toolbar{
+  position:absolute;
+  right:10px;
+  top:60px;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  z-index:9999;
+  background:#fff;
+  border:1px solid #ddd;
+  border-radius:8px;
+  padding:6px;
+  box-shadow:0 2px 8px rgba(0,0,0,.15);
+  font-size:13px;
+}
+.toolbar button{
+  border:none;
+  background:#f0f0f0;
+  border-radius:4px;
+  padding:5px;
+  cursor:pointer;
+  min-width:28px;
+  transition:background-color .2s;
+}
+.toolbar button:hover{background:#e2e2e2;}
+
+#colorPick{border:1px solid #b3b3b3;border-radius:4px;width:32px;height:23px;padding:0}


### PR DESCRIPTION
## Summary
- move panel styles into new `style.css`
- use Roboto font and new colors for a fresher look
- connect Font Awesome and replace menu labels with icons
- redesign mini-toolbar as a side panel
- register toolbar buttons via `Panels`/`Commands`

## Testing
- `pip install -r ExPlast/sitebuilder/backend/requirements.txt`
- `PYTHONPATH=. python -m pytest -q`