### PR TITLE
Check presence of builder.js

### DIFF
--- a/ExPlast/sitebuilder/backend/app/main.py
+++ b/ExPlast/sitebuilder/backend/app/main.py
@@ -100,12 +100,15 @@ def export_zip(pid: int, db: Session = Depends(get_db)):
 #                 ├─ frontend/
 #                 │   ├─ index.html
 #                 │   ├─ main.js
+#                 │   ├─ builder.js
 #                 │   └─ … (css, imgs)
 #                 └─ backend/
 FRONT_DIR = Path(__file__).resolve().parents[2] / "frontend"
 # если путь не найден → явная ошибка при старте
 if not FRONT_DIR.exists():
     raise RuntimeError(f"frontend directory not found: {FRONT_DIR}")
+if not (FRONT_DIR / "builder.js").exists():
+    raise RuntimeError(f"builder.js not found in frontend directory: {FRONT_DIR}")
 
 # отдаём всё содержимое папки,
 # html=True → запрос к '/' вернёт index.html


### PR DESCRIPTION
## Summary
- check builder.js existence when starting backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
