### PR TITLE
Improve project save flow

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -345,6 +345,7 @@ class Builder{
     const id = await chooseId('ID проекта для загрузки:');
     if(!id) return;
     curPid = id;
+    this.projectId = id;
     try{
       const pr = await api('GET',`/projects/${id}`);
       editor.loadProjectData(pr.data || {pages: []});
@@ -356,11 +357,16 @@ class Builder{
   }
 
   async saveProject(){
-    if(!curPid){
+    let pid = this.projectId;
+    if(!pid){
       const id = await chooseId('Сохранить в проект ID:');
-      if(!id) return; curPid=id;
+      if(!id) return;
+      pid = id;
+      this.projectId = id;
+      curPid = id;
     }
-    await saveAll(curPid);
+    const data = editor.getProjectData();
+    await api('PUT', `/projects/${pid}`, {name:'Сайт '+pid, data});
     alert('Сохранено');
   }
 


### PR DESCRIPTION
## Summary
- allow `loadProject` to remember the loaded ID
- ask for project ID when saving if not set
- send project data to backend and show confirmation

## Testing
- `pip install -q -r ExPlast/sitebuilder/backend/requirements.txt`
- `PYTHONPATH=ExPlast pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686528fb92d08332a09b5b47cf806c0a