### PR TITLE
Fix exporter for updated page structure

### DIFF
--- a/sitebuilder/__init__.py
+++ b/sitebuilder/__init__.py
@@ -1,0 +1,4 @@
+from importlib import import_module
+import sys
+mod = import_module('ExPlast.sitebuilder')
+sys.modules[__name__] = mod


### PR DESCRIPTION
## Summary
- update page render logic for new HTML/CSS structure
- handle list-based pages in ZIP builder
- expose package under `sitebuilder` for tests

## Testing
- `python -m pytest -q`