### PR TITLE
Добавлены плавные панели

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -153,12 +153,12 @@ document.addEventListener('click', e => {
   const el = e.target.closest('.draggable');
   if (el && builder.canvas.contains(el)) {
     selectedItem = el;
-    bar.hidden = false;
+    bar.classList.add('open');
     if (anchorRight) anchorRight.checked = !!el.dataset.anchorRight;
     if (anchorBottom) anchorBottom.checked = !!el.dataset.anchorBottom;
   } else {
     selectedItem = null;
-    bar.hidden = true;
+    bar.classList.remove('open');
   }
 });
 
@@ -297,7 +297,7 @@ class Builder {
       } else if (e.key === 'Delete' && this.selected) {
         this.selected.remove();
         this.selected = null;
-        if (bar) bar.hidden = true;
+        if (bar) bar.classList.remove('open');
         this.updateLayers();
         this.saveState();
       }
@@ -460,18 +460,18 @@ class Builder {
   }
 
   async toggleConfig() {
-    if (this.configPanel.hidden) {
-      this.cfgName.value = this.project.name;
-      this.cfgBg.value = this.project.config.bgColor;
-      this.cfgGrid.value = this.project.config.grid;
-      this.configPanel.hidden = false;
-    } else {
+    if (this.configPanel.classList.contains('open')) {
       this.project.name = this.cfgName.value;
       this.project.config.bgColor = this.cfgBg.value;
       this.project.config.grid = parseInt(this.cfgGrid.value) || 0;
       this.applyConfig();
-      this.configPanel.hidden = true;
+      this.configPanel.classList.remove('open');
       await this.saveProject();
+    } else {
+      this.cfgName.value = this.project.name;
+      this.cfgBg.value = this.project.config.bgColor;
+      this.cfgGrid.value = this.project.config.grid;
+      this.configPanel.classList.add('open');
     }
   }
 
@@ -599,7 +599,7 @@ class Builder {
     if (this.selected) this.selected.classList.remove('selected');
     this.selected = el;
     if (!el) {
-      bar?.setAttribute('hidden', '');
+      bar?.classList.remove('open');
       if (this.propW) this.propW.value = '';
       if (this.propH) this.propH.value = '';
       if (this.propFont) this.propFont.value = '';
@@ -611,7 +611,7 @@ class Builder {
     const r = el.getBoundingClientRect();
     bar.style.left = r.right + 5 + 'px';
     bar.style.top  = r.top + 'px';
-    bar?.removeAttribute('hidden');
+    bar?.classList.add('open');
     if (pick) {
       const rgb = getComputedStyle(el).color;
       const nums = rgb.match(/\d+/g);

--- a/ExPlast/sitebuilder/frontend/index.html
+++ b/ExPlast/sitebuilder/frontend/index.html
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <div id="configPanel" hidden>
+  <div id="configPanel">
     <label>Название: <input type="text" id="cfgName"></label>
     <label>Цвет фона: <input type="color" id="cfgBg"></label>
     <label>Шаг сетки: <input type="number" id="cfgGrid" min="1"></label>
@@ -41,7 +41,7 @@
   </div>
 
   <!-- панель блоков -->
-  <div id="blocksBar" class="toolbar">
+  <div id="blocksBar" class="toolbar open">
     <button onclick="addBlock('text')">Текст</button>
     <button onclick="addBlock('image')">Картинка</button>
     <button onclick="addBlock('header')">Заголовок</button>
@@ -49,7 +49,7 @@
   </div>
 
   <!-- панель слоёв -->
-  <div id="layersPanel" class="toolbar">
+  <div id="layersPanel" class="toolbar open">
     <ul id="layersList"></ul>
     <div style="display:flex;gap:4px;">
       <button id="layerUp" class="toolbar-btn" title="Вверх">↑</button>
@@ -59,7 +59,7 @@
   </div>
 
   <!-- мини-панель -->
-  <div id="inlineToolbar" class="toolbar" hidden>
+  <div id="inlineToolbar" class="toolbar">
     <input  type="color" id="colorPick" title="Цвет текста">
     <label title="К правому краю" style="user-select:none">
       ⇢<input type="checkbox" id="anchorRight" style="margin-left:4px">
@@ -70,7 +70,7 @@
   </div>
 
   <!-- панель свойств -->
-  <div id="propsPanel" class="toolbar">
+  <div id="propsPanel" class="toolbar open">
     <label>Ширина: <input type="number" id="propWidth" min="1"></label>
     <label>Высота: <input type="number" id="propHeight" min="1"></label>
     <label>Размер шрифта: <input type="number" id="propFont" min="1"></label>

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -138,6 +138,15 @@ html,body{
   box-shadow:var(--shadow);
   font-size:13px;
   color:#fff;
+  opacity:0;
+  transform:scale(.95);
+  pointer-events:none;
+  transition:opacity .2s, transform .2s;
+}
+.toolbar.open{
+  opacity:1;
+  transform:scale(1);
+  pointer-events:auto;
 }
 .toolbar button{
   border:none;
@@ -183,7 +192,7 @@ html,body{
   position:absolute;
   left:50%;
   top:80px;
-  transform:translateX(-50%);
+  transform:translateX(-50%) scale(.95);
   background:#fff;
   color:#000;
   border:1px solid #555;
@@ -191,8 +200,15 @@ html,body{
   padding:10px;
   box-shadow:var(--shadow);
   z-index:10000;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .2s, transform .2s;
 }
-#configPanel[hidden]{display:none;}
+#configPanel.open{
+  opacity:1;
+  transform:translateX(-50%) scale(1);
+  pointer-events:auto;
+}
 #configPanel label{display:block;margin:4px 0;}
 
 /* панель свойств */


### PR DESCRIPTION
## Изменения
- панели имеют плавное появление через класс `open`
- класс `open` применяется при работе с `configPanel` и мини-панелями
- панели по умолчанию скрыты с `opacity:0` и `scale(.95)`

## Тестирование
- `pytest -q` *(падает: ModuleNotFoundError: No module named 'fastapi')*