### PR TITLE
Исправления стилей для масштабирования

### DIFF
--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -1,6 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
 
 :root{
+  --font-base:16px;
+  --font-family:'Roboto',sans-serif;
   --color-bg:#f0f5f7;
   --color-panel:#2f3e48;
   --color-primary:#38b2ac;
@@ -26,11 +28,12 @@ html.theme-dark{
 html,body{
   margin:0;
   height:100%;
-  font-family:'Roboto',sans-serif;
+  font-family:var(--font-family);
+  font-size:var(--font-base);
 }
 
 #canvas{
-  height:calc(100vh - 54px);
+  height:calc(100vh - 3.375rem);
   background:var(--color-bg);
 }
 
@@ -68,29 +71,29 @@ html,body{
 
 .draggable .resize-handle{
   position:absolute;
-  width:8px;
-  height:8px;
+  width:0.5rem;
+  height:0.5rem;
   background:#fff;
   border:1px solid var(--color-primary);
   box-sizing:border-box;
   display:none;
 }
 .draggable.selected .resize-handle{display:block;}
-.resize-handle[data-dir="nw"]{left:-4px;top:-4px;cursor:nwse-resize;}
-.resize-handle[data-dir="ne"]{right:-4px;top:-4px;cursor:nesw-resize;}
-.resize-handle[data-dir="sw"]{left:-4px;bottom:-4px;cursor:nesw-resize;}
+.resize-handle[data-dir="nw"]{left:-0.25rem;top:-0.25rem;cursor:nwse-resize;}
+.resize-handle[data-dir="ne"]{right:-0.25rem;top:-0.25rem;cursor:nesw-resize;}
+.resize-handle[data-dir="sw"]{left:-0.25rem;bottom:-0.25rem;cursor:nesw-resize;}
 
-.resize-handle[data-dir="se"]{right:-4px;bottom:-4px;cursor:nwse-resize;}
+.resize-handle[data-dir="se"]{right:-0.25rem;bottom:-0.25rem;cursor:nwse-resize;}
 
 /* базовые блоки */
 .block-text{
-  padding:4px;
+  padding:0.25rem;
   color:#333;
 }
 
 .block-button{
   display:inline-block;
-  padding:6px 12px;
+  padding:0.375rem 0.75rem;
   background:var(--color-primary);
   color:#fff;
   border-radius:var(--radius);
@@ -104,40 +107,40 @@ html,body{
 }
 
 .toolbar-btn{
-  padding:5px;
-  min-width:28px;
+  padding:0.3125rem;
+  min-width:1.75rem;
 }
 
 /* верхняя панель */
 #topBar{
-  padding:6px 12px;
+  padding:0.375rem 0.75rem;
   background:var(--color-panel);
   display:flex;
-  gap:8px;
+  gap:0.5rem;
   align-items:center;
   color:#fff;
   box-shadow:var(--shadow);
 }
 #topBar button{
-  padding:4px 8px;
+  padding:0.25rem 0.5rem;
   display:flex;
   align-items:center;
-  gap:4px;
+  gap:0.25rem;
 }
 
 /* панель страниц */
 #pagesBar{
-  margin-left:32px;
+  margin-left:2rem;
   display:flex;
-  gap:4px;
+  gap:0.25rem;
   background:var(--color-panel);
-  padding:4px 8px;
+  padding:0.25rem 0.5rem;
   border-radius:var(--radius);
   box-shadow:var(--shadow);
 }
 
 #pagesBar select{
-  padding:4px 6px;
+  padding:0.25rem 0.375rem;
   border:1px solid #555;
   border-radius:var(--radius);
   background:var(--color-panel);
@@ -150,7 +153,7 @@ html,body{
 }
 
 #pagesBar button{
-  padding:4px 8px;
+  padding:0.25rem 0.5rem;
 }
 
 /* боковая мини-панель */
@@ -160,12 +163,12 @@ html,body{
   top:60px;
   display:flex;
   flex-direction:column;
-  gap:6px;
+  gap:0.375rem;
   z-index:9999;
   background:rgba(47,62,72,0.8);
   border:1px solid #555;
   border-radius:var(--radius);
-  padding:6px;
+  padding:0.375rem;
   box-shadow:var(--shadow);
   font-size:13px;
   color:#fff;
@@ -180,24 +183,25 @@ html,body{
   pointer-events:auto;
 }
 .toolbar button{
-  padding:5px;
-  min-width:28px;
+  padding:0.3125rem;
+  min-width:1.75rem;
 }
 
 .panel-title{
   background:var(--color-panel);
   border:1px solid #555;
   border-radius:var(--radius);
-  padding:4px 6px;
-  margin:-6px -6px 6px -6px;
+  padding:0.25rem 0.375rem;
+  margin:-0.375rem -0.375rem 0.375rem -0.375rem;
+  font-size:1.1rem;
   text-align:center;
 }
 
 #colorPick{
   border:1px solid #777;
   border-radius:var(--radius);
-  width:32px;
-  height:23px;
+  width:2rem;
+  height:1.4375rem;
   padding:0;
   background:#fff;
 }
@@ -230,7 +234,7 @@ html,body{
   color:#000;
   border:1px solid #555;
   border-radius:var(--radius);
-  padding:10px;
+  padding:0.625rem;
   box-shadow:var(--shadow);
   z-index:10000;
   opacity:0;
@@ -242,14 +246,14 @@ html,body{
   transform:translateX(-50%) scale(1);
   pointer-events:auto;
 }
-#configPanel label{display:block;margin:4px 0;}
+#configPanel label{display:block;margin:0.25rem 0;}
 
 /* панель свойств */
 #propsPanel label{
   display:flex;
   justify-content:space-between;
   align-items:center;
-  gap:4px;
+  gap:0.25rem;
 }
 #propsPanel input[type="number"]{
   width:60px;


### PR DESCRIPTION
## Summary
- подключили базовый размер и семейство шрифта через CSS‑переменные
- перешли на `rem` для высоты и отступов элементов
- увеличили шрифт заголовков панелей

## Testing
- `pytest -q` *(ошибка: ModuleNotFoundError: No module named 'fastapi')*
