### PR TITLE
Исправление блока изображения

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -100,7 +100,7 @@ function addBlock(type) {
       html = '<div class="draggable block-text" contenteditable="true" style="left:20px;top:20px;">Текст</div>';
       break;
     case 'image':
-      html = '<img class="draggable block-image" style="left:20px;top:20px;" src="https://via.placeholder.com/150">';
+      html = '<div class="block-image draggable" style="left:20px;top:20px;"><img src="https://via.placeholder.com/150"></div>';
       break;
     case 'header':
       html = '<h1 class="draggable block-text" contenteditable="true" style="left:20px;top:20px;">Заголовок</h1>';

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -108,6 +108,12 @@ html,body{
   box-shadow:0 2px 4px rgba(0,0,0,.2);
 }
 
+.block-image img{
+  width:100%;
+  height:100%;
+  object-fit:contain;
+}
+
 .toolbar-btn{
   padding:0.3125rem;
   min-width:1.75rem;


### PR DESCRIPTION
## Summary
- уточнены стили для изображений внутри блока `.block-image`
- при добавлении изображения теперь создаётся контейнер `<div class="block-image draggable">`

## Testing
- `pytest -q` *(падает: ModuleNotFoundError: No module named 'fastapi')*
