### PR TITLE
Add styles for site blocks

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -103,7 +103,7 @@ function addBlock(type) {
       html = '<div class="block-image draggable" style="left:20px;top:20px;"><img src="https://via.placeholder.com/150"></div>';
       break;
     case 'header':
-      html = '<h1 class="draggable block-text" contenteditable="true" style="left:20px;top:20px;">Заголовок</h1>';
+      html = '<h1 class="draggable block-header" contenteditable="true" style="left:20px;top:20px;">Заголовок</h1>';
       break;
     case 'button':
       html = '<a class="draggable block-button" href="#" style="left:20px;top:20px;">Кнопка</a>';

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -94,6 +94,17 @@ html,body{
 .block-text{
   padding:0.25rem;
   color:#333;
+  min-width:100px;
+  min-height:30px;
+}
+
+.block-header{
+  padding:0.25rem;
+  color:#333;
+  font-size:1.5rem;
+  font-weight:bold;
+  min-width:120px;
+  min-height:40px;
 }
 
 .block-button{
@@ -103,12 +114,16 @@ html,body{
   color:var(--color-text);
   border-radius:var(--radius);
   transition:background-color .2s;
+  min-width:80px;
+  text-align:center;
 }
 .block-button:hover{background:var(--color-primary-hover);}
 
 .block-image{
   border:2px solid #ddd;
   box-shadow:0 2px 4px rgba(0,0,0,.2);
+  width:150px;
+  height:150px;
 }
 
 .block-image img{


### PR DESCRIPTION
## Summary
- style basic blocks in CSS with default sizes and colors
- update builder to apply `block-header` class

## Testing
- `pytest -q`
