### PR TITLE
Enhance inline editing toolbar

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -657,6 +657,7 @@ class Builder {
       }
       let top = r.top;
       if (top < 0) top = 0;
+      bar.style.right = '';
       bar.style.left = left + 'px';
       bar.style.top  = top + 'px';
       bar.classList.add('open');

--- a/ExPlast/sitebuilder/frontend/index.html
+++ b/ExPlast/sitebuilder/frontend/index.html
@@ -63,7 +63,7 @@
   </div>
 
   <!-- мини-панель -->
-  <div id="inlineToolbar" class="toolbar">
+  <div id="inlineToolbar" class="toolbar inline-toolbar">
     <input  type="color" id="colorPick" title="Цвет текста">
     <label title="К правому краю" style="user-select:none">
       ⇢<input type="checkbox" id="anchorRight" style="margin-left:4px">

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -217,6 +217,21 @@ html,body{
   min-width:1.75rem;
 }
 
+.inline-toolbar{
+  position:absolute;
+  right:auto;
+  top:auto;
+  flex-direction:row;
+  gap:0.25rem;
+  padding:0.25rem;
+  font-size:0.75rem;
+  background:rgba(47,62,72,0.9);
+}
+.inline-toolbar input[type="color"]{
+  width:1.2rem;
+  height:1.2rem;
+}
+
 .panel-title{
   background:var(--color-panel);
   border:1px solid #555;


### PR DESCRIPTION
## Summary
- add `inline-toolbar` class in HTML for inline editing panel
- style inline toolbar for row layout
- reset `style.right` when positioning panel in builder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686645506f1c8332a3829d3dea314ce4