### PR TITLE
Fix inline toolbar bounds

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -657,8 +657,13 @@ class Builder {
       }
       let top = r.top;
       if (top < 0) top = 0;
+      if (top + bar.offsetHeight > window.innerHeight) {
+        top = window.innerHeight - bar.offsetHeight;
+        if (top < 0) top = 0;
+      }
       bar.style.left = left + 'px';
       bar.style.top  = top + 'px';
+      bar.style.right = 'auto';
       bar.classList.add('open');
     }
     if (pick) {


### PR DESCRIPTION
## Summary
- prevent inline toolbar from going off the bottom edge
- ensure `right` style is cleared when showing toolbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866455249848332ae7dfa66293427a2