### PR TITLE
Реализован drag&drop блоков

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -1,5 +1,6 @@
 // Простые обработчики перетаскивания элементов
 let dragItem = null, dx = 0, dy = 0, moved = false;
+let dragBlockType = null;
 let resizeItem = null, resizeDir = '', rx = 0, ry = 0, rw = 0, rh = 0, rl = 0, rt = 0;
 let selectedItem = null;
 const anchorRight = document.getElementById('anchorRight');
@@ -109,26 +110,35 @@ document.addEventListener('mouseup', () => {
 });
 
 // Создание блоков
-function addBlock(type) {
+function addBlock(type, x = 20, y = 20) {
   let html = '';
   switch (type) {
     case 'text':
-      html = '<div class="draggable block-text" contenteditable="true" style="left:20px;top:20px;">Текст</div>';
+      html = '<div class="draggable block-text" contenteditable="true">Текст</div>';
       break;
     case 'image':
-      html = '<div class="block-image draggable" style="left:20px;top:20px;"><img src="https://via.placeholder.com/150"></div>';
+      html = '<div class="block-image draggable"><img src="https://via.placeholder.com/150"></div>';
       break;
     case 'header':
-      html = '<h1 class="draggable block-header" contenteditable="true" style="left:20px;top:20px;">Заголовок</h1>';
+      html = '<h1 class="draggable block-header" contenteditable="true">Заголовок</h1>';
       break;
     case 'button':
-      html = '<a class="draggable block-button" href="#" style="left:20px;top:20px;">Кнопка</a>';
+      html = '<a class="draggable block-button" href="#">Кнопка</a>';
       break;
   }
   if (html && builder.canvas) {
     builder.canvas.insertAdjacentHTML('beforeend', html);
     const el = builder.canvas.lastElementChild;
+    const step = builder.project?.config?.grid || 0;
+    if (step > 0) {
+      x = Math.round(x / step) * step;
+      y = Math.round(y / step) * step;
+    }
+    el.style.left = x + 'px';
+    el.style.top = y + 'px';
     el.dataset.layerId = ++builder.layerId;
+    el.dataset.x = x;
+    el.dataset.y = y;
     addResizeHandles(el);
     builder.updateLayers();
     builder.saveState();
@@ -325,6 +335,30 @@ class Builder {
     this.layerUp.onclick    = () => this.moveLayer(1);
     this.layerDown.onclick  = () => this.moveLayer(-1);
     this.layerToggle.onclick= () => this.toggleLayer();
+
+    this.blocksBar = document.getElementById('blocksBar');
+    if (this.blocksBar) {
+      for (const item of this.blocksBar.querySelectorAll('.block-item')) {
+        item.addEventListener('dragstart', () => {
+          dragBlockType = item.dataset.type;
+        });
+      }
+    }
+
+    if (this.canvas) {
+      this.canvas.addEventListener('dragover', e => {
+        if (dragBlockType) e.preventDefault();
+      });
+      this.canvas.addEventListener('drop', e => {
+        if (!dragBlockType) return;
+        e.preventDefault();
+        const rect = this.canvas.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        addBlock(dragBlockType, x, y);
+        dragBlockType = null;
+      });
+    }
 
     this.canvas.addEventListener('click', e => {
       const el = e.target.closest('.draggable');

--- a/ExPlast/sitebuilder/frontend/index.html
+++ b/ExPlast/sitebuilder/frontend/index.html
@@ -45,10 +45,18 @@
   <!-- панель блоков -->
   <div id="blocksBar" class="toolbar open">
     <h3 class="panel-title">Блоки</h3>
-    <button onclick="addBlock('text')">Текст</button>
-    <button onclick="addBlock('image')">Картинка</button>
-    <button onclick="addBlock('header')">Заголовок</button>
-    <button onclick="addBlock('button')">Кнопка</button>
+    <div class="block-item" draggable="true" data-type="text">
+      <i class="fa fa-font"></i><span>Текст</span>
+    </div>
+    <div class="block-item" draggable="true" data-type="image">
+      <i class="fa fa-image"></i><span>Картинка</span>
+    </div>
+    <div class="block-item" draggable="true" data-type="header">
+      <i class="fa fa-heading"></i><span>Заголовок</span>
+    </div>
+    <div class="block-item" draggable="true" data-type="button">
+      <i class="fa fa-link"></i><span>Кнопка</span>
+    </div>
   </div>
 
   <!-- панель слоёв -->

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -264,6 +264,21 @@ html,body{
   right:auto;
 }
 
+.block-item{
+  display:flex;
+  align-items:center;
+  gap:0.25rem;
+  padding:0.25rem 0.375rem;
+  border:1px solid #555;
+  border-radius:var(--radius);
+  background:rgba(255,255,255,0.1);
+  cursor:grab;
+  user-select:none;
+}
+.block-item:active{cursor:grabbing;}
+.block-item i{width:1rem;text-align:center;}
+.block-item span{pointer-events:none;}
+
 /* панель слоёв */
 #layersPanel{
   left:170px;


### PR DESCRIPTION
## Изменения
- панель блоков теперь содержит элементы `block-item`, поддерживающие перетаскивание
- добавлены стили для новых элементов
- реализована логика `dragstart/dragover/drop` в `builder.js`
- функция `addBlock` принимает координаты

## Тесты
- `python -m pytest -q`