### PR TITLE
Add editor hotkeys

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -435,6 +435,22 @@ class Builder {
           e.preventDefault();
           this.pasteElement();
         }
+      } else if (e.ctrlKey && e.key.toLowerCase() === 'a') {
+        if (this.canvas) {
+          e.preventDefault();
+          this.selectElement(null);
+          for (const el of this.canvas.querySelectorAll('.draggable')) {
+            this.selectElement(el, true);
+          }
+        }
+      } else if (e.ctrlKey && e.key.toLowerCase() === 'd') {
+        if (this.selectedItems.length) {
+          e.preventDefault();
+          this.duplicateSelected();
+        }
+      } else if (e.ctrlKey && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        this.saveProject(true);
       } else if (e.key === 'Delete' && this.selectedItems.length) {
         for (const it of this.selectedItems) it.remove();
         this.selectedItems = [];
@@ -585,9 +601,13 @@ class Builder {
       } catch { alert('Нет проекта'); }
   }
 
-  async saveProject() {
+  async saveProject(silent = false) {
     if (!this.project.name) {
-      this.project.name = prompt('Название проекта', 'Сайт') || 'Site';
+      if (silent) {
+        this.project.name = 'Site';
+      } else {
+        this.project.name = prompt('Название проекта', 'Сайт') || 'Site';
+      }
     }
     this.project.pages[this.current].html = this.canvas.innerHTML;
     if (!this.project.id) {
@@ -602,7 +622,7 @@ class Builder {
         data: { pages: this.project.pages, config: this.project.config },
       });
     }
-    alert('Сохранено');
+    if (!silent) alert('Сохранено');
   }
 
   async exportProject() {
@@ -949,6 +969,32 @@ class Builder {
     this.canvas.appendChild(clone);
     addResizeHandles(clone);
     this.selectElement(clone);
+    this.updateLayers();
+    this.saveState();
+  }
+
+  duplicateSelected() {
+    if (!this.canvas || !this.selectedItems.length) return;
+    const clones = [];
+    for (const item of this.selectedItems) {
+      const cs = getComputedStyle(item);
+      const clone = item.cloneNode(true);
+      clone.classList.remove('selected');
+      clone.dataset.layerId = ++this.layerId;
+      clone.style.right = '';
+      clone.style.bottom = '';
+      delete clone.dataset.anchorRight;
+      delete clone.dataset.anchorBottom;
+      const left = parseFloat(cs.left) || 0;
+      const top = parseFloat(cs.top) || 0;
+      clone.style.left = (left + 20) + 'px';
+      clone.style.top  = (top + 20) + 'px';
+      this.canvas.appendChild(clone);
+      addResizeHandles(clone);
+      clones.push(clone);
+    }
+    this.selectElement(null);
+    for (const cl of clones) this.selectElement(cl, true);
     this.updateLayers();
     this.saveState();
   }

--- a/ExPlast/sitebuilder/frontend/index.html
+++ b/ExPlast/sitebuilder/frontend/index.html
@@ -24,6 +24,7 @@
     <button id="btnConfig" class="btn"><i class="fa fa-gear"></i><span> Настройки</span></button>
     <button id="btnTheme" class="btn" title="Сменить тему">🌙</button>
     <button id="btnPreview" class="btn"><i class="fa fa-eye"></i><span> Предпросмотр</span></button>
+    <button id="btnHelp" class="btn" title="Ctrl+Z — отмена, Ctrl+Y — повтор, Ctrl+C — копировать, Ctrl+V — вставить, Ctrl+A — выделить все, Ctrl+D — дублировать, Ctrl+S — сохранить, Delete — удалить">?</button>
 
     <!-- панель страниц -->
     <div id="pagesBar">


### PR DESCRIPTION
## Summary
- добавить горячие клавиши: Ctrl+A выбор всех блоков, Ctrl+D дублирование, Ctrl+S тихое сохранение
- обновить функцию сохранения с параметром `silent`
- добавить всплывающую подсказку со списком доступных комбинаций

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686667151088833283fd5cd018d7a8dc