### PR TITLE
Implement theme-based grid color

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -707,7 +707,8 @@ class Builder {
       this.gridCanvas.style.display = 'none';
       return;
     }
-    ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+    const color = getComputedStyle(this.gridCanvas).getPropertyValue('--grid-color');
+    ctx.strokeStyle = color;
     ctx.lineWidth = 1;
     for (let x = 0; x <= w; x += step) {
       ctx.beginPath();

--- a/ExPlast/sitebuilder/frontend/style.css
+++ b/ExPlast/sitebuilder/frontend/style.css
@@ -10,6 +10,7 @@
   --radius:6px;
   --shadow:0 4px 8px rgba(0,0,0,.3);
   --color-text:#fff;
+  --grid-color:rgba(0,0,0,0.2);
 }
 
 html.theme-light{
@@ -18,6 +19,7 @@ html.theme-light{
   --color-primary:#38b2ac;
   --color-primary-hover:#2d9c94;
   --color-text:#fff;
+  --grid-color:rgba(0,0,0,0.2);
 }
 
 html.theme-dark{
@@ -26,6 +28,7 @@ html.theme-dark{
   --color-primary:#4b86c2;
   --color-primary-hover:#3b6e9b;
   --color-text:#fff;
+  --grid-color:rgba(255,255,255,0.2);
 }
 
 html,body{


### PR DESCRIPTION
## Summary
- add `--grid-color` CSS variable with light and dark values
- use computed grid color in `drawGrid`

## Testing
- `pip install -r ExPlast/sitebuilder/backend/requirements.txt`
- `pytest -q`