### PR TITLE
Add language switcher

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -10,6 +10,71 @@ const anchorRight = document.getElementById('anchorRight');
 const anchorBottom = document.getElementById('anchorBottom');
 const AUTO_SAVE_KEY = 'builderAutosave';
 
+const LANG_KEY = 'uiLang';
+const i18n = {
+  ru: {
+    create:'Создать', load:'Загрузить', import:'Импорт', save:'Сохранить',
+    export:'Экспорт', settings:'Настройки', preview:'Предпросмотр', grid:'Сетка',
+    themeTip:'Сменить тему', helpTip:'Ctrl+Z — отмена, Ctrl+Y — повтор, Ctrl+C — копировать, Ctrl+V — вставить, Ctrl+A — выделить все, Ctrl+D — дублировать, Ctrl+S — сохранить, Delete — удалить',
+    newPageTitle:'Новая страница', deletePageTitle:'Удалить страницу', blocks:'Блоки',
+    blockText:'Текст', blockImage:'Картинка', blockHeader:'Заголовок', blockButton:'Кнопка',
+    layers:'Слои', layerUpTitle:'Вверх', layerDownTitle:'Вниз', layerToggleTitle:'Показать/скрыть',
+    inlineColorTitle:'Цвет текста', anchorRightTitle:'К правому краю', anchorBottomTitle:'К нижнему краю',
+    props:'Свойства', saved:'Сохранено', noProject:'Нет проекта', exportError:'Ошибка экспорта',
+    unknownFormat:'Неизвестный формат', importError:'Ошибка импорта', alreadyExists:'Уже есть',
+    lastPage:'Последняя страница', restoreConfirm:'Обнаружена сохранённая копия. Восстановить?',
+    projectNamePrompt:'Название проекта', projectDefaultName:'Сайт', projectIdPrompt:'ID проекта',
+    newPagePrompt:'Имя новой страницы (без .html):',
+    deleteConfirm:'Удалить',
+    cfgNameLabel:'Название:', cfgBgLabel:'Цвет фона:', cfgBgImageLabel:'Фоновое изображение:', cfgGridLabel:'Шаг сетки:',
+    widthLabel:'Ширина:', heightLabel:'Высота:', fontSizeLabel:'Размер шрифта:', textColorLabel:'Цвет текста:',
+    alignLabel:'Выравнивание:', familyLabel:'Семейство шрифта:', styleLabel:'Начертание:', fontBoldTitle:'Жирный', fontItalicTitle:'Курсив',
+    fillColorLabel:'Цвет заливки:', borderWidthLabel:'Толщина рамки:', borderColorLabel:'Цвет рамки:', radiusLabel:'Радиус:',
+    shadowLabel:'Тень:', imgUrlLabel:'URL изображения:', altTextLabel:'Alt текст:', linkLabel:'Ссылка:', openNewTabLabel:'Открывать в новой вкладке',
+    alignLeft:'Слева', alignCenter:'Центр', alignRight:'Справа', alignJustify:'По ширине', familyDefault:'По умолчанию'
+  },
+  en: {
+    create:'Create', load:'Load', import:'Import', save:'Save',
+    export:'Export', settings:'Settings', preview:'Preview', grid:'Grid',
+    themeTip:'Toggle theme', helpTip:'Ctrl+Z — undo, Ctrl+Y — redo, Ctrl+C — copy, Ctrl+V — paste, Ctrl+A — select all, Ctrl+D — duplicate, Ctrl+S — save, Delete — remove',
+    newPageTitle:'New page', deletePageTitle:'Delete page', blocks:'Blocks',
+    blockText:'Text', blockImage:'Image', blockHeader:'Header', blockButton:'Button',
+    layers:'Layers', layerUpTitle:'Up', layerDownTitle:'Down', layerToggleTitle:'Show/hide',
+    inlineColorTitle:'Text color', anchorRightTitle:'Anchor right', anchorBottomTitle:'Anchor bottom',
+    props:'Properties', saved:'Saved', noProject:'No project', exportError:'Export error',
+    unknownFormat:'Unknown format', importError:'Import error', alreadyExists:'Already exists',
+    lastPage:'Last page', restoreConfirm:'Found autosave. Restore?',
+    projectNamePrompt:'Project name', projectDefaultName:'Site', projectIdPrompt:'Project ID',
+    newPagePrompt:'New page name (without .html):',
+    deleteConfirm:'Delete',
+    cfgNameLabel:'Name:', cfgBgLabel:'Background color:', cfgBgImageLabel:'Background image:', cfgGridLabel:'Grid step:',
+    widthLabel:'Width:', heightLabel:'Height:', fontSizeLabel:'Font size:', textColorLabel:'Text color:',
+    alignLabel:'Alignment:', familyLabel:'Font family:', styleLabel:'Style:', fontBoldTitle:'Bold', fontItalicTitle:'Italic',
+    fillColorLabel:'Fill color:', borderWidthLabel:'Border width:', borderColorLabel:'Border color:', radiusLabel:'Radius:',
+    shadowLabel:'Shadow:', imgUrlLabel:'Image URL:', altTextLabel:'Alt text:', linkLabel:'Link:', openNewTabLabel:'Open in new tab',
+    alignLeft:'Left', alignCenter:'Center', alignRight:'Right', alignJustify:'Justify', familyDefault:'Default'
+  }
+};
+
+function t(key){
+  const lang = localStorage.getItem(LANG_KEY) || 'ru';
+  return (i18n[lang] && i18n[lang][key]) || i18n.ru[key] || key;
+}
+
+function applyLang(lang){
+  localStorage.setItem(LANG_KEY, lang);
+  const dict = i18n[lang] || i18n.ru;
+  document.querySelectorAll('[data-i18n]').forEach(el=>{
+    if(dict[el.dataset.i18n]) el.textContent = dict[el.dataset.i18n];
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el=>{
+    if(dict[el.dataset.i18nTitle]) el.title = dict[el.dataset.i18nTitle];
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el=>{
+    if(dict[el.dataset.i18nPlaceholder]) el.placeholder = dict[el.dataset.i18nPlaceholder];
+  });
+}
+
 document.addEventListener('mousedown', e => {
   const handle = e.target.closest('.resize-handle');
   if (handle) {
@@ -138,16 +203,16 @@ function addBlock(type, x = 20, y = 20) {
   let html = '';
   switch (type) {
     case 'text':
-      html = '<div class="draggable block-text" contenteditable="true">Текст</div>';
+      html = `<div class="draggable block-text" contenteditable="true">${t('blockText')}</div>`;
       break;
     case 'image':
       html = '<div class="block-image draggable"><img src="https://via.placeholder.com/150"></div>';
       break;
     case 'header':
-      html = '<h1 class="draggable block-header" contenteditable="true">Заголовок</h1>';
+      html = `<h1 class="draggable block-header" contenteditable="true">${t('blockHeader')}</h1>`;
       break;
     case 'button':
-      html = '<a class="draggable block-button" href="#">Кнопка</a>';
+      html = `<a class="draggable block-button" href="#">${t('blockButton')}</a>`;
       break;
   }
   if (html && builder.canvas) {
@@ -297,6 +362,7 @@ class Builder {
     this.btnExport   = document.getElementById('btnExport');
     this.btnConfig   = document.getElementById('btnConfig');
     this.btnPreview  = document.getElementById('btnPreview');
+    this.langSelect  = document.getElementById('langSelect');
     this.toggleGrid  = document.getElementById('toggleGrid');
     this.pageSelect  = document.getElementById('pageSelect');
     this.pageAdd     = document.getElementById('pageAdd');
@@ -343,13 +409,19 @@ class Builder {
 
     this.theme = localStorage.getItem('theme') || 'light';
     this.applyTheme(this.theme);
+    if(this.langSelect){
+      const lang = localStorage.getItem(LANG_KEY) || 'ru';
+      this.langSelect.value = lang;
+      applyLang(lang);
+      this.langSelect.onchange = () => applyLang(this.langSelect.value);
+    }
 
     let restored = false;
     const saved = localStorage.getItem(AUTO_SAVE_KEY);
     if (saved) {
       try {
         const data = JSON.parse(saved);
-        if (confirm('Обнаружена сохранённая копия. Восстановить?')) {
+        if (confirm(t('restoreConfirm'))) {
           this.project = data.project || this.project;
           if (!this.project.config) this.project.config = { bgColor: '#fafafa', grid: 20, bgImage: '', showGrid: true };
           this.pages = Object.keys(this.project.pages);
@@ -597,7 +669,7 @@ class Builder {
   }
 
   async createProject() {
-    const name = prompt('Название проекта', 'Сайт');
+    const name = prompt(t('projectNamePrompt'), t('projectDefaultName'));
     if (!name) return;
     this.project = {
       id: null,
@@ -613,7 +685,7 @@ class Builder {
   }
 
   async loadProject() {
-    const id = parseInt(prompt('ID проекта', this.project.id || '1'));
+    const id = parseInt(prompt(t('projectIdPrompt'), this.project.id || '1'));
     if (!id) return;
     try {
       const pr = await api('GET', `/projects/${id}`);
@@ -628,15 +700,15 @@ class Builder {
       this.updateSelect();
       this.switchPage(this.pages[0]);
       this.applyConfig();
-      } catch { alert('Нет проекта'); }
+      } catch { alert(t('noProject')); }
   }
 
   async saveProject(silent = false) {
     if (!this.project.name) {
       if (silent) {
-        this.project.name = 'Site';
+        this.project.name = t('projectDefaultName');
       } else {
-        this.project.name = prompt('Название проекта', 'Сайт') || 'Site';
+        this.project.name = prompt(t('projectNamePrompt'), t('projectDefaultName')) || t('projectDefaultName');
       }
     }
     this.project.pages[this.current].html = this.canvas.innerHTML;
@@ -653,17 +725,17 @@ class Builder {
       });
     }
     localStorage.removeItem(AUTO_SAVE_KEY);
-    alert('Сохранено');
+    alert(t('saved'));
   }
 
   async exportProject() {
-    if (!this.project.id) { alert('Нет проекта'); return; }
+    if (!this.project.id) { alert(t('noProject')); return; }
     try {
       const blob = await (await fetch(`/projects/${this.project.id}/export`)).blob();
       const u = URL.createObjectURL(blob);
       Object.assign(document.createElement('a'), { href: u, download: 'site.zip' }).click();
       URL.revokeObjectURL(u);
-    } catch { alert('Ошибка экспорта'); }
+    } catch { alert(t('exportError')); }
   }
 
   async importProject() {
@@ -684,7 +756,7 @@ class Builder {
         }
         this.project = { id: null, name: file.name.replace(/\.zip$/i, ''), pages, config: { bgColor: '#fafafa', grid: 20, bgImage: '', showGrid: true } };
       } else {
-        alert('Неизвестный формат');
+        alert(t('unknownFormat'));
         return;
       }
       if (!this.project.config) this.project.config = { bgColor: '#fafafa', grid: 20, bgImage: '', showGrid: true };
@@ -694,15 +766,15 @@ class Builder {
       this.applyConfig();
       this.setupDraggables();
     } catch {
-      alert('Ошибка импорта');
+      alert(t('importError'));
     } finally {
       this.fileImport.value = '';
     }
   }
 
   addPage() {
-    const id = prompt('Имя новой страницы (без .html):', 'about');
-    if (!id || this.project.pages[id]) { alert('Уже есть'); return; }
+    const id = prompt(t('newPagePrompt'), 'about');
+    if (!id || this.project.pages[id]) { alert(t('alreadyExists')); return; }
     this.project.pages[id] = { html: '' };
     this.pages.push(id);
     const o = document.createElement('option');
@@ -713,9 +785,9 @@ class Builder {
   }
 
   deletePage() {
-    if (this.pages.length <= 1) { alert('Последняя страница'); return; }
+    if (this.pages.length <= 1) { alert(t('lastPage')); return; }
     const id = this.pageSelect.value;
-    if (!confirm(`Удалить ${id}?`)) return;
+    if (!confirm(`${t('deleteConfirm')} ${id}?`)) return;
     delete this.project.pages[id];
     const idx = this.pages.indexOf(id);
     if (idx >= 0) {

--- a/ExPlast/sitebuilder/frontend/index.html
+++ b/ExPlast/sitebuilder/frontend/index.html
@@ -16,32 +16,36 @@
 
   <!-- ── верхняя панель ── -->
   <div id="topBar">
-    <button id="btnCreate" class="btn"><i class="fa fa-file-circle-plus"></i><span> Создать</span></button>
-    <button id="btnLoad" class="btn"><i class="fa fa-folder-open"></i><span> Загрузить</span></button>
-    <button id="btnImport" class="btn"><i class="fa fa-file-import"></i><span> Импорт</span></button>
-    <button id="btnSave" class="btn"><i class="fa fa-floppy-disk"></i><span> Сохранить</span></button>
-    <button id="btnExport" class="btn"><i class="fa fa-file-export"></i><span> Экспорт</span></button>
-    <button id="btnConfig" class="btn"><i class="fa fa-gear"></i><span> Настройки</span></button>
-    <button id="btnTheme" class="btn" title="Сменить тему">🌙</button>
-    <button id="btnPreview" class="btn"><i class="fa fa-eye"></i><span> Предпросмотр</span></button>
+    <button id="btnCreate" class="btn"><i class="fa fa-file-circle-plus"></i><span data-i18n="create">Создать</span></button>
+    <button id="btnLoad" class="btn"><i class="fa fa-folder-open"></i><span data-i18n="load">Загрузить</span></button>
+    <button id="btnImport" class="btn"><i class="fa fa-file-import"></i><span data-i18n="import">Импорт</span></button>
+    <button id="btnSave" class="btn"><i class="fa fa-floppy-disk"></i><span data-i18n="save">Сохранить</span></button>
+    <button id="btnExport" class="btn"><i class="fa fa-file-export"></i><span data-i18n="export">Экспорт</span></button>
+    <button id="btnConfig" class="btn"><i class="fa fa-gear"></i><span data-i18n="settings">Настройки</span></button>
+    <button id="btnTheme" class="btn" title="" data-i18n-title="themeTip">🌙</button>
+    <button id="btnPreview" class="btn"><i class="fa fa-eye"></i><span data-i18n="preview">Предпросмотр</span></button>
     <label class="btn" style="display:flex;align-items:center;gap:4px;user-select:none">
-      <input type="checkbox" id="toggleGrid" style="margin:0"> Сетка
+      <input type="checkbox" id="toggleGrid" style="margin:0"> <span data-i18n="grid">Сетка</span>
     </label>
-    <button id="btnHelp" class="btn" title="Ctrl+Z — отмена, Ctrl+Y — повтор, Ctrl+C — копировать, Ctrl+V — вставить, Ctrl+A — выделить все, Ctrl+D — дублировать, Ctrl+S — сохранить, Delete — удалить">?</button>
+    <button id="btnHelp" class="btn" data-i18n-title="helpTip">?</button>
+    <select id="langSelect" class="btn">
+      <option value="ru">Русский</option>
+      <option value="en">English</option>
+    </select>
 
     <!-- панель страниц -->
     <div id="pagesBar">
       <select id="pageSelect"></select>
-      <button id="pageAdd"  class="btn" title="Новая страница">＋</button>
-      <button id="pageDel"  class="btn" title="Удалить страницу">🗑</button>
+      <button id="pageAdd"  class="btn" data-i18n-title="newPageTitle">＋</button>
+      <button id="pageDel"  class="btn" data-i18n-title="deletePageTitle">🗑</button>
     </div>
   </div>
 
   <div id="configPanel">
-    <label>Название: <input type="text" id="cfgName"></label>
-    <label>Цвет фона: <input type="color" id="cfgBg"></label>
-    <label>Фоновое изображение: <input type="url" id="cfgBgImage" placeholder="URL"></label>
-    <label>Шаг сетки: <input type="number" id="cfgGrid" min="1"></label>
+    <label data-i18n="cfgNameLabel">Название: <input type="text" id="cfgName"></label>
+    <label data-i18n="cfgBgLabel">Цвет фона: <input type="color" id="cfgBg"></label>
+    <label data-i18n="cfgBgImageLabel">Фоновое изображение: <input type="url" id="cfgBgImage" placeholder="URL"></label>
+    <label data-i18n="cfgGridLabel">Шаг сетки: <input type="number" id="cfgGrid" min="1"></label>
   </div>
 
   <div id="canvas">
@@ -56,79 +60,79 @@
 
   <!-- панель блоков -->
   <div id="blocksBar" class="toolbar open">
-    <h3 class="panel-title">Блоки</h3>
+    <h3 class="panel-title" data-i18n="blocks">Блоки</h3>
     <div class="block-item" draggable="true" data-type="text">
-      <i class="fa fa-font"></i><span>Текст</span>
+      <i class="fa fa-font"></i><span data-i18n="blockText">Текст</span>
     </div>
     <div class="block-item" draggable="true" data-type="image">
-      <i class="fa fa-image"></i><span>Картинка</span>
+      <i class="fa fa-image"></i><span data-i18n="blockImage">Картинка</span>
     </div>
     <div class="block-item" draggable="true" data-type="header">
-      <i class="fa fa-heading"></i><span>Заголовок</span>
+      <i class="fa fa-heading"></i><span data-i18n="blockHeader">Заголовок</span>
     </div>
     <div class="block-item" draggable="true" data-type="button">
-      <i class="fa fa-link"></i><span>Кнопка</span>
+      <i class="fa fa-link"></i><span data-i18n="blockButton">Кнопка</span>
     </div>
   </div>
 
   <!-- панель слоёв -->
   <div id="layersPanel" class="toolbar open">
-    <h3 class="panel-title">Слои</h3>
+    <h3 class="panel-title" data-i18n="layers">Слои</h3>
     <ul id="layersList"></ul>
     <div style="display:flex;gap:4px;">
-      <button id="layerUp" class="btn toolbar-btn" title="Вверх">↑</button>
-      <button id="layerDown" class="btn toolbar-btn" title="Вниз">↓</button>
-      <button id="layerToggle" class="btn toolbar-btn" title="Показать/скрыть"><i class="fa fa-eye"></i></button>
+      <button id="layerUp" class="btn toolbar-btn" data-i18n-title="layerUpTitle">↑</button>
+      <button id="layerDown" class="btn toolbar-btn" data-i18n-title="layerDownTitle">↓</button>
+      <button id="layerToggle" class="btn toolbar-btn" data-i18n-title="layerToggleTitle"><i class="fa fa-eye"></i></button>
     </div>
   </div>
 
   <!-- мини-панель -->
   <div id="inlineToolbar" class="toolbar inline-toolbar">
-    <input  type="color" id="colorPick" title="Цвет текста">
-    <label title="К правому краю" style="user-select:none">
+    <input  type="color" id="colorPick" data-i18n-title="inlineColorTitle" title="Цвет текста">
+    <label data-i18n-title="anchorRightTitle" style="user-select:none">
       ⇢<input type="checkbox" id="anchorRight" style="margin-left:4px">
     </label>
-    <label title="К нижнему краю" style="user-select:none">
+    <label data-i18n-title="anchorBottomTitle" style="user-select:none">
       ⇣<input type="checkbox" id="anchorBottom" style="margin-left:4px">
     </label>
   </div>
 
   <!-- панель свойств -->
   <div id="propsPanel" class="toolbar open">
-    <h3 class="panel-title">Свойства</h3>
-    <label>Ширина: <input type="number" id="propWidth" min="1"></label>
-    <label>Высота: <input type="number" id="propHeight" min="1"></label>
-    <label>Размер шрифта: <input type="number" id="propFont" min="1"></label>
-    <label>Цвет текста: <input type="color" id="propColor"></label>
-    <label>Выравнивание:
+    <h3 class="panel-title" data-i18n="props">Свойства</h3>
+    <label data-i18n="widthLabel">Ширина: <input type="number" id="propWidth" min="1"></label>
+    <label data-i18n="heightLabel">Высота: <input type="number" id="propHeight" min="1"></label>
+    <label data-i18n="fontSizeLabel">Размер шрифта: <input type="number" id="propFont" min="1"></label>
+    <label data-i18n="textColorLabel">Цвет текста: <input type="color" id="propColor"></label>
+    <label data-i18n="alignLabel">Выравнивание:
       <select id="propAlign">
-        <option value="left">Слева</option>
-        <option value="center">Центр</option>
-        <option value="right">Справа</option>
-        <option value="justify">По ширине</option>
+        <option value="left" data-i18n="alignLeft">Слева</option>
+        <option value="center" data-i18n="alignCenter">Центр</option>
+        <option value="right" data-i18n="alignRight">Справа</option>
+        <option value="justify" data-i18n="alignJustify">По ширине</option>
       </select>
     </label>
-    <label>Семейство шрифта:
+    <label data-i18n="familyLabel">Семейство шрифта:
       <select id="propFamily">
-        <option value="">По умолчанию</option>
+        <option value="" data-i18n="familyDefault">По умолчанию</option>
         <option value="Arial, sans-serif">Arial</option>
         <option value="Tahoma, sans-serif">Tahoma</option>
         <option value="'Times New Roman', serif">Times</option>
       </select>
     </label>
-    <label>Начертание:
-      <input type="checkbox" id="propBold" title="Жирный">B
-      <input type="checkbox" id="propItalic" title="Курсив" style="margin-left:4px;">I
+    <label data-i18n="styleLabel">Начертание:
+      <input type="checkbox" id="propBold" title="" data-i18n-title="fontBoldTitle">B
+      <input type="checkbox" id="propItalic" title="" data-i18n-title="fontItalicTitle" style="margin-left:4px;">I
     </label>
-    <label>Цвет заливки: <input type="color" id="propBg"></label>
-    <label>Толщина рамки: <input type="number" id="propBorderWidth" min="0"></label>
-    <label>Цвет рамки: <input type="color" id="propBorderColor"></label>
-    <label>Радиус: <input type="number" id="propRadius" min="0"></label>
-    <label>Тень: <input type="checkbox" id="propShadow"></label>
-    <label id="propSrcRow" style="display:none;">URL изображения: <input type="url" id="propSrc" placeholder="https://..."></label>
-    <label id="propAltRow" style="display:none;">Alt текст: <input type="text" id="propAlt"></label>
-    <label id="propHrefRow" style="display:none;">Ссылка: <input type="url" id="propHref" placeholder="https://..."></label>
-    <label id="propTargetRow" style="display:none;"><input type="checkbox" id="propTarget" style="margin-right:4px;">Открывать в новой вкладке</label>
+    <label data-i18n="fillColorLabel">Цвет заливки: <input type="color" id="propBg"></label>
+    <label data-i18n="borderWidthLabel">Толщина рамки: <input type="number" id="propBorderWidth" min="0"></label>
+    <label data-i18n="borderColorLabel">Цвет рамки: <input type="color" id="propBorderColor"></label>
+    <label data-i18n="radiusLabel">Радиус: <input type="number" id="propRadius" min="0"></label>
+    <label data-i18n="shadowLabel">Тень: <input type="checkbox" id="propShadow"></label>
+    <label id="propSrcRow" style="display:none;" data-i18n="imgUrlLabel">URL изображения: <input type="url" id="propSrc" placeholder="https://..."></label>
+    <label id="propAltRow" style="display:none;" data-i18n="altTextLabel">Alt текст: <input type="text" id="propAlt"></label>
+    <label id="propHrefRow" style="display:none;" data-i18n="linkLabel">Ссылка: <input type="url" id="propHref" placeholder="https://..."></label>
+    <label id="propTargetRow" style="display:none;" data-i18n="openNewTabLabel"><input type="checkbox" id="propTarget" style="margin-right:4px;">Открывать в новой вкладке</label>
   </div>
 
   <input type="file" id="fileImport" accept=".json,.zip" style="display:none">


### PR DESCRIPTION
## Summary
- implement i18n dictionary and helper functions
- update builder initialization to use saved language
- add language selector in the top panel
- mark UI elements with data attributes for translation
- expand dictionary with labels and translate new block defaults

## Testing
- `pytest -q`