### PR TITLE
Switch tests to temp SQLite

### DIFF
--- a/ExPlast/sitebuilder/backend/tests/test_export.py
+++ b/ExPlast/sitebuilder/backend/tests/test_export.py
@@ -1,3 +1,11 @@
+import os
+import tempfile
+
+# перед импорта приложения переключаем БД на временный файл
+fd, path = tempfile.mkstemp(suffix=".db")
+os.close(fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+
 from fastapi.testclient import TestClient
 
 # путь к вашему приложению (вы раньше использовали именно sitebuilder.backend)

--- a/ExPlast/sitebuilder/backend/tests/test_pages.py
+++ b/ExPlast/sitebuilder/backend/tests/test_pages.py
@@ -1,3 +1,11 @@
+import os
+import tempfile
+
+# переключаем БД на временный файл до импорта приложения
+fd, path = tempfile.mkstemp(suffix=".db")
+os.close(fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+
 from fastapi.testclient import TestClient
 from sitebuilder.backend.app.main import app
 from sitebuilder.backend.app.database import Base, engine

--- a/ExPlast/sitebuilder/backend/tests/test_projects.py
+++ b/ExPlast/sitebuilder/backend/tests/test_projects.py
@@ -1,3 +1,11 @@
+import os
+import tempfile
+
+# выбираем временный SQLite-файл до импорта приложения
+fd, path = tempfile.mkstemp(suffix=".db")
+os.close(fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+
 from fastapi.testclient import TestClient
 from sitebuilder.backend.app.main import app
 from sitebuilder.backend.app.database import Base, engine


### PR DESCRIPTION
## Summary
- use temporary sqlite databases in test modules so that builder.db is untouched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f6bf329c833286a580f88a4e65ed