### PR TITLE
Add title persistence for pages

### DIFF
--- a/ExPlast/sitebuilder/backend/app/crud.py
+++ b/ExPlast/sitebuilder/backend/app/crud.py
@@ -92,6 +92,7 @@ def create_page(db: Session, pid: int, page: schemas.PageCreate):
     db_pg = models.ProjectPage(
         project_id=pid,
         name=page.name,
+        title=page.title,
         data=_dumps(page.data),
     )
     db.add(db_pg)
@@ -99,7 +100,6 @@ def create_page(db: Session, pid: int, page: schemas.PageCreate):
     db.refresh(db_pg)
     db.expunge(db_pg)
     res = _attach_page(db_pg)
-    res.title = page.title or res.title
     return res
 
 
@@ -133,14 +133,12 @@ def update_page(db: Session, pid: int, pgid: int, page: schemas.PageUpdate):
         db_pg.name = page.name
     if page.data is not None:
         db_pg.data = _dumps(page.data)
-    # title храним только в ответе
+    if page.title is not None:
+        db_pg.title = page.title
     db.commit()
     db.refresh(db_pg)
     db.expunge(db_pg)
-    res = _attach_page(db_pg)
-    if page.title is not None:
-        res.title = page.title
-    return res
+    return _attach_page(db_pg)
 
 
 def delete_page(db: Session, pid: int, pgid: int) -> bool:

--- a/ExPlast/sitebuilder/backend/tests/test_pages.py
+++ b/ExPlast/sitebuilder/backend/tests/test_pages.py
@@ -15,14 +15,18 @@ def test_pages_crud():
     # create page
     pg = client.post(f"/projects/{pid}/pages", json={"name":"about","title":"О нас","data":{}}).json()
     assert pg["name"]=="about"
+    assert pg["title"]=="О нас"
 
     # list
     lst=client.get(f"/projects/{pid}/pages").json()
     assert len(lst)==1
+    assert lst[0]["title"]=="О нас"
 
     # update
     upd=client.put(f"/projects/{pid}/pages/{pg['id']}", json={"title":"About Us"}).json()
     assert upd["title"]=="About Us"
+    updated=client.get(f"/projects/{pid}/pages/{pg['id']}").json()
+    assert updated["title"]=="About Us"
 
     # delete
     del_resp = client.delete(f"/projects/{pid}/pages/{pg['id']}")
@@ -38,6 +42,7 @@ def test_get_page():
     r = client.get(f"/projects/{pid}/pages/{pgid}")
     assert r.status_code == 200
     assert r.json()["id"] == pgid
+    assert r.json()["title"] == "О нас"
 
     r2 = client.get(f"/projects/{pid}/pages/9999")
     assert r2.status_code == 404


### PR DESCRIPTION
## Summary
- store `ProjectPage.title` during creation and updates
- adjust tests to verify page title is persisted

## Testing
- `pip install -r ExPlast/sitebuilder/backend/requirements.txt`
- `pytest -q`
