### PR TITLE
Add flake8 config and lint script

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .git,__pycache__,.venv

--- a/ExPlast/sitebuilder/backend/app/database.py
+++ b/ExPlast/sitebuilder/backend/app/database.py
@@ -8,6 +8,7 @@ engine = create_engine(DATABASE_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 Base = declarative_base()
 
+
 def get_db():
     db = SessionLocal()
     try:

--- a/ExPlast/sitebuilder/backend/app/exporter.py
+++ b/ExPlast/sitebuilder/backend/app/exporter.py
@@ -17,6 +17,7 @@ _HTML = """<!doctype html>
 {{ html|safe }}
 </body></html>"""
 
+
 def _render(page: ProjectPage, config: dict | None = None) -> bytes:
     """Собрать полноценную HTML‑страницу из данных страницы."""
 
@@ -52,6 +53,7 @@ def _render(page: ProjectPage, config: dict | None = None) -> bytes:
     body_attr = f" style=\"{' ; '.join(body_style)}\"" if body_style else ""
 
     return tpl.render(title=page.name, html=html, css=css, body_attr=body_attr).encode()
+
 
 def build_zip(project: Project, db: Session) -> str:
     """Создать tmp-zip и вернуть его путь.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Проверить код на стиль flake8
+python3 -m flake8 ExPlast/sitebuilder/backend/app/crud.py \
+    ExPlast/sitebuilder/backend/app/database.py \
+    ExPlast/sitebuilder/backend/app/exporter.py


### PR DESCRIPTION
## Summary
- configure flake8 with line length 120
- add lint script
- fix E302 around functions in database and exporter modules

## Testing
- `pytest -q`
- `./scripts/lint.sh`