### PR TITLE
Исправление инициализации drag-системы

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -46,7 +46,9 @@ class Builder {
   setupDraggables() {
     if (!this.canvas) return;
     for (const el of this.canvas.querySelectorAll('.draggable')) {
-      window.addResizeHandles(el);
+      if (window.addResizeHandles) {
+        window.addResizeHandles(el);
+      }
     }
   }
 

--- a/ExPlast/sitebuilder/frontend/drag.js
+++ b/ExPlast/sitebuilder/frontend/drag.js
@@ -176,3 +176,4 @@ export function addResizeHandles(el) {
 
 window.addBlock = addBlock;
 window.addResizeHandles = addResizeHandles;
+builder.setupDraggables();


### PR DESCRIPTION
## Summary
- добавил проверку наличия `addResizeHandles` в `builder.js`
- после загрузки `drag.js` добавляю рукоятки для уже имеющихся элементов

## Testing
- `pytest -q`
- запустил headless Chrome через puppeteer, убедившись в отсутствии JS-ошибок
