### PR TITLE
Fix builder initialization after modularization

### DIFF
--- a/ExPlast/sitebuilder/frontend/builder.js
+++ b/ExPlast/sitebuilder/frontend/builder.js
@@ -6,10 +6,12 @@ import Builder from './modules/builder-class.js';
 const builder = new Builder();
 window.builder = builder;
 
-initDrag(builder);
-initToolbar(builder);
-
-builder.init();
+// Инициализируем модули только после полной загрузки DOM
+window.addEventListener('DOMContentLoaded', () => {
+  initDrag(builder);
+  initToolbar(builder);
+  builder.init();
+});
 
 window.addBlock = (type, x = 20, y = 20) => addBlock(builder, type, x, y);
 export default builder;


### PR DESCRIPTION
## Summary
- wait for DOMContentLoaded before initializing drag and toolbar modules

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b657ea2083329b9c3672cc6af016