### PR TITLE
Fix export filenames and add zip safety tests

### DIFF
--- a/ExPlast/sitebuilder/backend/app/exporter.py
+++ b/ExPlast/sitebuilder/backend/app/exporter.py
@@ -3,10 +3,19 @@ import zipfile
 import tempfile
 import json
 import base64
+import re
 from types import SimpleNamespace
 from jinja2 import Template
 from sqlalchemy.orm import Session
 from .models import Project, ProjectPage
+
+_SAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def _safe_name(name: str) -> str:
+    """Вернуть безопасное имя файла."""
+    return _SAFE_RE.sub("_", name)
+
 
 _HTML = """<!doctype html>
 <html lang="ru"><head>
@@ -48,7 +57,7 @@ def _render(page: ProjectPage, config: dict | None = None) -> bytes:
         if bg:
             body_style.append(f"background:{bg}")
         if cfg.get("style"):
-            css = f"{css}\n{cfg.get('style')}" if css else cfg.get('style')
+            css = f"{css}\n{cfg.get('style')}" if css else cfg.get("style")
 
     body_attr = f" style=\"{' ; '.join(body_style)}\"" if body_style else ""
 
@@ -87,27 +96,35 @@ def build_zip(project: Project, db: Session) -> str:
     pages = list(pages_dict.values())
 
     tmp_fd, tmp_name = tempfile.mkstemp(suffix=".zip")
-    os.close(tmp_fd)                    # zipfile сам будет писать
+    os.close(tmp_fd)  # zipfile сам будет писать
 
     with zipfile.ZipFile(tmp_name, "w", zipfile.ZIP_DEFLATED) as zf:
         cfg = project.data.get("config") if isinstance(project.data, dict) else {}
         for pg in pages:
             html_bytes = _render(pg, cfg)
-            fname = ("index" if pg.name == "index" else pg.name) + ".html"
+            pname = _safe_name(pg.name)
+            if not pname:
+                continue
+            fname = ("index" if pname == "index" else pname) + ".html"
             zf.writestr(fname, html_bytes)
 
-        proj_data = project.data.get("project") if isinstance(project.data, dict) else {}
+        proj_data = (
+            project.data.get("project") if isinstance(project.data, dict) else {}
+        )
         assets = proj_data.get("assets") if isinstance(proj_data, dict) else []
         for idx, asset in enumerate(assets, 1):
             src = asset.get("src")
             if not src or not src.startswith("data:"):
                 continue
             name = asset.get("name") or f"asset{idx}"
+            aname = _safe_name(name)
+            if not aname:
+                continue
             try:
                 header, b64 = src.split(",", 1)
                 data = base64.b64decode(b64)
             except Exception:
                 continue
-            zf.writestr(f"assets/{name}", data)
+            zf.writestr(f"assets/{aname}", data)
 
     return tmp_name

--- a/ExPlast/sitebuilder/backend/tests/test_export.py
+++ b/ExPlast/sitebuilder/backend/tests/test_export.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 # путь к вашему приложению (вы раньше использовали именно sitebuilder.backend)
 from sitebuilder.backend.app.main import app
+import base64
 from sitebuilder.backend.app.database import Base, engine
 from sitebuilder.backend.app import exporter
 import zipfile
@@ -17,10 +18,12 @@ import io
 
 client = TestClient(app)
 
+
 # фикстура: «чистая БД перед каждым тестом»
 def setup_function():
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
+
 
 def test_export_zip():
     # 1. создаём минимальный проект в новой структуре
@@ -31,7 +34,7 @@ def test_export_zip():
     resp = client.get(f"/projects/{pid}/export")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/zip"
-    assert resp.content[:2] == b"PK"        # ZIP-подпись
+    assert resp.content[:2] == b"PK"  # ZIP-подпись
 
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         html = zf.read("index.html").decode()
@@ -55,3 +58,32 @@ def test_export_file_removed(monkeypatch, tmp_path):
     assert resp.status_code == 200
     resp.close()
     assert not path.exists()
+
+
+def test_export_sanitize_names():
+    img = base64.b64encode(b"img").decode()
+    data = {
+        "pages": {
+            "bad/../name": {"html": "hi", "css": ""},
+        },
+        "project": {
+            "assets": [
+                {"src": f"data:text/plain;base64,{img}", "name": "pic/../evil.png"}
+            ]
+        },
+    }
+    pid = client.post("/projects/", json={"name": "X", "data": data}).json()["id"]
+
+    resp = client.get(f"/projects/{pid}/export")
+    assert resp.status_code == 200
+
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        names = zf.namelist()
+        assert "bad____name.html" in names
+        assert "assets/pic____evil_png" in names
+        for name in names:
+            assert ".." not in name
+            if name.startswith("assets/"):
+                assert "/" not in name[len("assets/") :]
+            else:
+                assert "/" not in name


### PR DESCRIPTION
## Summary
- sanitize page and asset filenames when creating zip archives
- test that exported zip has sanitized names without path traversal

## Testing
- `pytest -q`